### PR TITLE
Add a config option to change the OSC listening port, and an error popup

### DIFF
--- a/VRBrations/Config.cs
+++ b/VRBrations/Config.cs
@@ -1,10 +1,7 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace VRCToyController
 {
@@ -69,6 +66,7 @@ namespace VRCToyController
         //Serialized Values
         public float update_rate = 100;
         public float threshold = 0.05f;
+        public ushort osc_listen_port = 9001;
         public List<DeviceData> devices;
 
         //Private Non Serialized values

--- a/VRBrations/OSCInterface.cs
+++ b/VRBrations/OSCInterface.cs
@@ -1,11 +1,8 @@
 ﻿using SharpOSC;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Sockets;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+using System.Windows.Forms;
 using VRCToyController;
 
 namespace VRbrations
@@ -33,7 +30,15 @@ namespace VRbrations
                 
             };
 
-            var listener = new UDPListener(9001, cb);
+            try
+            {
+                var listener = new UDPListener(Config.Singleton.osc_listen_port, cb);
+            } catch (SocketException)
+            {
+                MessageBox.Show(
+                    "Couldn't bind to OSC input port; please close any other OSC programs and retry.", "Socket Bind Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                throw;
+            }
         }
 
         static void HandleOSCMessage(OscMessage message)


### PR DESCRIPTION
The app was just crashing immediately on startup without any explanation, since I had another OSC program already running in the background.  I added a simple "failed to bind" dialog box to make it easier for people in the future, as well as the ability to change the bind port in case you've got other OSC programs running as well.